### PR TITLE
Dont print exception

### DIFF
--- a/tcppinglib/tcp_ping.py
+++ b/tcppinglib/tcp_ping.py
@@ -106,6 +106,6 @@ async def async_tcpping(
                 rtts.append(request.time)
 
             except Exception as e:
-                print(e)
+                raise Exception(f'exception while tcpping {address}', e)
 
     return TCPHost(address, port, packets_sent, count - packets_sent, rtts)

--- a/tcppinglib/tcp_ping.py
+++ b/tcppinglib/tcp_ping.py
@@ -67,7 +67,7 @@ def tcpping(
                 rtts.append(request.time)
 
             except Exception as e:
-                print(e)
+                raise Exception(f'exception while tcpping {address}', e)
 
     return TCPHost(address, port, packets_sent, count - packets_sent, rtts)
 


### PR DESCRIPTION
Its not wise to be printing exceptions. People may have their own exception handling in their applications and this printing will spam the logs.