### PR TITLE
add stddev feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ tcpping(address, port: int = 80, timeout: float = 2, count: int = 3, interval: f
 #### Return Value
 
 - A `TcpHost` object will be returned containing with many usefull values about the TCP Ping. <br>
-`ip_address`, `port`, `packets_sent`, `packets_received`, `packet_loss`, `is_alive`, `min_rtt`, `avg_rtt`, `max_rtt`
+`ip_address`, `port`, `packets_sent`, `packets_received`, `packet_loss`, `is_alive`, `min_rtt`, `avg_rtt`, `max_rtt`, `stddev_rtt`
 
 #### Example
 
@@ -178,7 +178,7 @@ multi_tcpping(addresses: list, port: int = 80, timeout: float = 2, count: int = 
 #### Return Value
 
 - A `TcpHost` object will be returned containing with many usefull values about the TCP Ping. <br>
-`ip_address`, `port`, `packets_sent`, `packets_received`, `packet_loss`, `is_alive`, `min_rtt`, `avg_rtt`, `max_rtt`
+`ip_address`, `port`, `packets_sent`, `packets_received`, `packet_loss`, `is_alive`, `min_rtt`, `avg_rtt`, `max_rtt`, `stddev_rtt`
 
 #### Example
 
@@ -255,7 +255,7 @@ async_tcpping(address, port: int = 80, timeout: float = 2, count: int = 5, inter
 #### Return Value
 
 - A `TcpHost` object will be returned containing with many usefull values about the TCP Ping. <br>
-`ip_address`, `port`, `packets_sent`, `packets_received`, `packet_loss`, `is_alive`, `min_rtt`, `avg_rtt`, `max_rtt`
+`ip_address`, `port`, `packets_sent`, `packets_received`, `packet_loss`, `is_alive`, `min_rtt`, `avg_rtt`, `max_rtt`, `stddev_rtt`
 
 #### Example
 
@@ -333,7 +333,7 @@ async_multi_tcpping(address, port: int = 80, timeout: float = 2, count: int = 5,
 #### Return Value
 
 - A `TcpHost` object will be returned containing with many usefull values about the TCP Ping. <br>
-`ip_address`, `port`, `packets_sent`, `packets_received`, `packet_loss`, `is_alive`, `min_rtt`, `avg_rtt`, `max_rtt`
+`ip_address`, `port`, `packets_sent`, `packets_received`, `packet_loss`, `is_alive`, `min_rtt`, `avg_rtt`, `max_rtt`, `stddev_rtt`
 
 #### Example
 

--- a/examples/multi_tcpping.py
+++ b/examples/multi_tcpping.py
@@ -22,28 +22,28 @@ for host in hosts:
 
 #   142.250.187.174
 # ------------------------------------------------------------
-#   Packets sent:                    10
-#   Packets received:                10
-#   Packet lost:                     0
-#   Packet loss:                     0.0%
-#   Overall Round-trip times:        225.093 ms / 231.98 ms / 249.058 ms
+#   Packets sent:                           10
+#   Packets received:                       10
+#   Packet lost:                            0
+#   Packet loss:                            0.0%
+#   Overall Round-trip times:               225.093 ms / 231.98 ms / 249.058 ms
 #   min/avg/max/stddev Round-trip times:    1.662 ms / 8.052 ms / 33.093 ms / 3.232 ms
 # ------------------------------------------------------------
 #   151.101.67.5
 # ------------------------------------------------------------
-#   Packets sent:                    10
-#   Packets received:                10
-#   Packet lost:                     0
-#   Packet loss:                     0.0%
-#   min/avg/max Round-trip times:    156.232 ms / 214.811 ms / 426.994 ms / 34.323 ms
+#   Packets sent:                           10
+#   Packets received:                       10
+#   Packet lost:                            0
+#   Packet loss:                            0.0%
+#   min/avg/max/stddev Round-trip times:    156.232 ms / 214.811 ms / 426.994 ms / 34.323 ms
 # ------------------------------------------------------------
 #   138.197.63.241
 # ------------------------------------------------------------
-#   Packets sent:                    10
-#   Packets received:                10
-#   Packet lost:                     0
-#   Packet loss:                     0.0%
-#   min/avg/max Round-trip times:    119.124 ms / 178.133 ms / 387.641 ms / 54.354 ms
+#   Packets sent:                           10
+#   Packets received:                       10
+#   Packet lost:                            0
+#   Packet loss:                            0.0%
+#   min/avg/max/stddev Round-trip times:    119.124 ms / 178.133 ms / 387.641 ms / 54.354 ms
 # ------------------------------------------------------------
 
 

--- a/examples/multi_tcpping.py
+++ b/examples/multi_tcpping.py
@@ -27,7 +27,7 @@ for host in hosts:
 #   Packet lost:                     0
 #   Packet loss:                     0.0%
 #   Overall Round-trip times:        225.093 ms / 231.98 ms / 249.058 ms
-#   min/avg/max Round-trip times:    1.662 ms / 8.052 ms / 33.093 ms
+#   min/avg/max/stddev Round-trip times:    1.662 ms / 8.052 ms / 33.093 ms / 3.232 ms
 # ------------------------------------------------------------
 #   151.101.67.5
 # ------------------------------------------------------------
@@ -35,7 +35,7 @@ for host in hosts:
 #   Packets received:                10
 #   Packet lost:                     0
 #   Packet loss:                     0.0%
-#   min/avg/max Round-trip times:    156.232 ms / 214.811 ms / 426.994 ms
+#   min/avg/max Round-trip times:    156.232 ms / 214.811 ms / 426.994 ms / 34.323 ms
 # ------------------------------------------------------------
 #   138.197.63.241
 # ------------------------------------------------------------
@@ -43,7 +43,7 @@ for host in hosts:
 #   Packets received:                10
 #   Packet lost:                     0
 #   Packet loss:                     0.0%
-#   min/avg/max Round-trip times:    119.124 ms / 178.133 ms / 387.641 ms
+#   min/avg/max Round-trip times:    119.124 ms / 178.133 ms / 387.641 ms / 54.354 ms
 # ------------------------------------------------------------
 
 

--- a/examples/tcpping.py
+++ b/examples/tcpping.py
@@ -35,6 +35,6 @@ print(
 
 
 print(
-    f"overall_min: {host.min_rtt}, overall_avg: {host.avg_rtt}, overall_max: {host.max_rtt}"
+    f"overall_min: {host.min_rtt}, overall_avg: {host.avg_rtt}, overall_max: {host.max_rtt},  overall_stddev: {host.stddev_rtt}"
 )
-# overall_min: 215.57, overall_avg: 270.47, overall_max: 700.475
+# overall_min: 215.57, overall_avg: 270.47, overall_max: 700.475, overall_stddev: 143.454

--- a/tcppinglib/models.py
+++ b/tcppinglib/models.py
@@ -24,6 +24,7 @@
     <https://www.gnu.org/licenses/>.
 '''
 
+
 class TCPRequest:
     """
     Object that represents a TCP reuqest making 3way handshake.
@@ -120,14 +121,14 @@ class TCPHost:
 
     def __str__(self):
         return (
-            f"-" * 60 + "\n"
-            f"  {self._destination}\n" + "-" * 60 + "\n"
-            f"  Packets sent:                    {self._packets_sent}\n"
-            f"  Packets received:                {self.packets_received}\n"
-            f"  Packet lost:                     {self._packet_lost}\n"
-            f"  Packet loss:                     {self.packet_loss}%\n"
-            f"  min/avg/max Round-trip times:    {self.min_rtt} ms / {self.avg_rtt} ms / {self.max_rtt} ms\n"
-            + "-" * 60
+                f"-" * 60 + "\n"
+                            f"  {self._destination}\n" + "-" * 60 + "\n"
+                                                                    f"  Packets sent:                           {self._packets_sent}\n"
+                                                                    f"  Packets received:                       {self.packets_received}\n"
+                                                                    f"  Packet lost:                            {self._packet_lost}\n"
+                                                                    f"  Packet loss:                            {self.packet_loss}%\n"
+                                                                    f"  min/avg/max/stddev Round-trip times:    {self.min_rtt} ms / {self.avg_rtt} ms / {self.max_rtt} ms / {self.stddev_rtt} ms\n"
+                + "-" * 60
         )
 
     @property
@@ -210,3 +211,13 @@ class TCPHost:
             return 0.0
 
         return round(max(self._rtts) * 1000, 3)
+
+    @property
+    def stddev_rtt(self):
+        """
+        The standard deviation of successfull connection time in milliseconds.
+        """
+        if not self._rtts:
+            return 0.0
+
+        return round((sum([(self.avg_rtt - rtt) ** 2 for rtt in self._rtts]) / len(self._rtts)) ** 0.5 * 1000, 3)

--- a/tcppinglib/models.py
+++ b/tcppinglib/models.py
@@ -220,4 +220,4 @@ class TCPHost:
         if not self._rtts:
             return 0.0
 
-        return round((sum([(self.avg_rtt - rtt) ** 2 for rtt in self._rtts]) / len(self._rtts)) ** 0.5 * 1000, 3)
+        return round((sum([(sum(self._rtts) / len(self._rtts) - rtt) ** 2 for rtt in self._rtts]) / len(self._rtts)) ** 0.5 * 1000, 3)


### PR DESCRIPTION
Similar to ICMP ping, add property to calculate standard deviation.

```
user@MacBook-Pro ~ % ping -c 5 google.de
PING google.de (142.250.186.131): 56 data bytes
64 bytes from 142.250.186.131: icmp_seq=0 ttl=60 time=15.538 ms
64 bytes from 142.250.186.131: icmp_seq=1 ttl=60 time=5.323 ms
64 bytes from 142.250.186.131: icmp_seq=2 ttl=60 time=5.029 ms
64 bytes from 142.250.186.131: icmp_seq=3 ttl=60 time=5.058 ms
64 bytes from 142.250.186.131: icmp_seq=4 ttl=60 time=286.262 ms

--- google.de ping statistics ---
5 packets transmitted, 5 packets received, 0.0% packet loss
round-trip min/avg/max/stddev = 5.029/63.442/286.262/111.483 ms
```

```
#   138.197.63.241
# ------------------------------------------------------------
#   Packets sent:                           10
#   Packets received:                       10
#   Packet lost:                            0
#   Packet loss:                            0.0%
#   min/avg/max/stddev Round-trip times:    119.124 ms / 178.133 ms / 387.641 ms / 54.354 ms
# ------------------------------------------------------------
```