### PR TITLE
Feat/issue8

### DIFF
--- a/tcppinglib/models.py
+++ b/tcppinglib/models.py
@@ -1,4 +1,4 @@
-'''
+"""
     tcppinglib
     ~~~~~~~
     
@@ -22,7 +22,8 @@
     You should have received a copy of the GNU Lesser General Public
     License along with this program.  If not, see
     <https://www.gnu.org/licenses/>.
-'''
+"""
+
 
 class TCPRequest:
     """
@@ -171,7 +172,9 @@ class TCPHost:
         if not self._packets_sent:
             return 0.0
 
-        return round((self._packet_lost / self._packets_sent) * 100, 2)
+        return round(
+            (self._packet_lost / (self._packets_sent + self._packet_lost)) * 100, 2
+        )
 
     @property
     def is_alive(self):

--- a/tcppinglib/models.py
+++ b/tcppinglib/models.py
@@ -172,9 +172,7 @@ class TCPHost:
         if not self._packets_sent:
             return 0.0
 
-        return round(
-            (self._packet_lost / (self._packets_sent + self._packet_lost)) * 100, 2
-        )
+        return round((self._packet_lost / self._packets_sent) * 100, 2)
 
     @property
     def is_alive(self):

--- a/tcppinglib/tcp_multiping.py
+++ b/tcppinglib/tcp_multiping.py
@@ -25,6 +25,7 @@
 """
 
 import asyncio
+
 from .tcp_ping import async_tcpping
 
 

--- a/tcppinglib/tcp_ping.py
+++ b/tcppinglib/tcp_ping.py
@@ -68,7 +68,7 @@ def tcpping(
             except Exception as e:
                 print(e)
 
-    return TCPHost(address, port, packets_sent, count - packets_sent, rtts)
+    return TCPHost(address, port, count, count - packets_sent, rtts)
 
 
 async def async_tcpping(
@@ -106,4 +106,4 @@ async def async_tcpping(
             except Exception as e:
                 print(e)
 
-    return TCPHost(address, port, packets_sent, count - packets_sent, rtts)
+    return TCPHost(address, port, count, count - packets_sent, rtts)

--- a/tcppinglib/tcp_ping.py
+++ b/tcppinglib/tcp_ping.py
@@ -40,7 +40,6 @@ def tcpping(
     count: int = 5,
     interval: float = 3,
 ):
-
     address = strip_http_https(address)
 
     if is_hostname(address):
@@ -79,7 +78,6 @@ async def async_tcpping(
     count: int = 5,
     interval: float = 3,
 ):
-
     address = strip_http_https(address)
 
     if is_hostname(address):
@@ -97,7 +95,7 @@ async def async_tcpping(
         with AsyncTCPSocket(_Socket()) as sock:
             if sequence > 0:
                 await asyncio.sleep(interval)
-            
+
             request = TCPRequest(destination=address, port=port, timeout=timeout)
 
             try:

--- a/tcppinglib/tcp_sockets.py
+++ b/tcppinglib/tcp_sockets.py
@@ -1,4 +1,4 @@
-'''
+"""
     tcppinglib
     ~~~~~~~
     
@@ -22,7 +22,7 @@
     You should have received a copy of the GNU Lesser General Public
     License along with this program.  If not, see
     <https://www.gnu.org/licenses/>.
-'''
+"""
 
 import socket
 import time
@@ -36,7 +36,6 @@ class TCPSocket:
     """
 
     def __init__(self) -> None:
-
         self._sock = None
         try:
             self._sock = self._create_socket(

--- a/tcppinglib/utils.py
+++ b/tcppinglib/utils.py
@@ -1,4 +1,4 @@
-'''
+"""
     tcppinglib
     ~~~~~~~
     
@@ -22,7 +22,7 @@
     You should have received a copy of the GNU Lesser General Public
     License along with this program.  If not, see
     <https://www.gnu.org/licenses/>.
-'''
+"""
 
 import asyncio
 import socket


### PR DESCRIPTION
TCPHost packet_loss property was returning wrong value. This PR fixes the packet_loss property along with formatting.
Also packets_sent value will be equal to count. Otherwise packets_sent and packets_received will always be the same. This way, it will visualise the whole stats properly.