### PR TITLE
Feat/printing urls

### DIFF
--- a/examples/async_multi_tcpping.py
+++ b/examples/async_multi_tcpping.py
@@ -8,8 +8,9 @@
 
     Examples for async_multi_tcpping
 """
-from tcppinglib import async_multi_tcpping
 import asyncio
+
+from tcppinglib import async_multi_tcpping
 
 urls = [
     # FQDNs

--- a/examples/async_tcpping.py
+++ b/examples/async_tcpping.py
@@ -9,8 +9,10 @@
     Examples for async_tcpping
 """
 
-from tcppinglib import async_tcpping
 import asyncio
+
+from tcppinglib import async_tcpping
+
 
 async def host_specs(address):
     host = await async_tcpping(address, count=7, interval=1.5)

--- a/tcppinglib/__init__.py
+++ b/tcppinglib/__init__.py
@@ -25,12 +25,11 @@
 '''
 
 from .exceptions import *
-from .tcp_ping import tcpping, async_tcpping
-from .tcp_multiping import multi_tcpping, async_multi_tcpping
 from .models import TCPHost, TCPRequest
-from .utils import is_hostname, is_ipv6, strip_http_https
-from .utils import hostname_lookup, async_hostname_lookup
-
+from .tcp_multiping import async_multi_tcpping, multi_tcpping
+from .tcp_ping import async_tcpping, tcpping
+from .utils import (async_hostname_lookup, hostname_lookup, is_hostname,
+                    is_ipv6, strip_http_https)
 
 __author__    = 'Engin EKEN'
 __copyright__ = 'Copyright 2021-2026 Engin EKEN'

--- a/tcppinglib/models.py
+++ b/tcppinglib/models.py
@@ -1,16 +1,16 @@
 """
     tcppinglib
     ~~~~~~~
-    
+
     Monitor your endpoints with TCP Ping.
 
         https://github.com/EnginEken/tcppinglib
-    
+
     :copyright: Copyright 2021-2026 Engin EKEN.
     :license: GNU LGPLv3, see the LICENSE for details.
-    
+
     ~~~~~~~
-    
+
     This program is free software: you can redistribute it and/or
     modify it under the terms of the GNU Lesser General Public License
     as published by the Free Software Foundation, either version 3 of
@@ -109,8 +109,9 @@ class TCPHost:
     :param rtts: The list of successfull connection times expressed in milliseconds.
     """
 
-    def __init__(self, destination, port, packets_sent, packet_lost, rtts):
+    def __init__(self, destination, url, port, packets_sent, packet_lost, rtts):
         self._destination = destination
+        self._url = url
         self._port = port
         self._packets_sent = packets_sent
         self._packet_lost = packet_lost
@@ -122,13 +123,17 @@ class TCPHost:
     def __str__(self):
         return (
             f"-" * 60 + "\n"
-            f"  {self._destination}\n" + "-" * 60 + "\n"
+            f"  {self._url + ' (' + self._destination + ')' if self._url else self._destination}\n"
+            + "-"
+            * 60
+            + "\n"
             f"  Packets sent:                           {self._packets_sent}\n"
             f"  Packets received:                       {self.packets_received}\n"
             f"  Packet lost:                            {self._packet_lost}\n"
             f"  Packet loss:                            {self.packet_loss}%\n"
             f"  min/avg/max/stddev Round-trip times:    {self.min_rtt} ms / {self.avg_rtt} ms / {self.max_rtt} ms / {self.stddev_rtt} ms\n"
-            + "-" * 60
+            + "-"
+            * 60
         )
 
     @property

--- a/tcppinglib/tcp_multiping.py
+++ b/tcppinglib/tcp_multiping.py
@@ -1,16 +1,16 @@
 """
     tcppinglib
     ~~~~~~~
-    
+
     Monitor your endpoints with TCP Ping.
 
         https://github.com/EnginEken/tcppinglib
-    
+
     :copyright: Copyright 2021-2026 Engin EKEN.
     :license: GNU LGPLv3, see the LICENSE for details.
-    
+
     ~~~~~~~
-    
+
     This program is free software: you can redistribute it and/or
     modify it under the terms of the GNU Lesser General Public License
     as published by the Free Software Foundation, either version 3 of

--- a/tcppinglib/tcp_ping.py
+++ b/tcppinglib/tcp_ping.py
@@ -1,16 +1,16 @@
 """
     tcppinglib
     ~~~~~~~
-    
+
     Monitor your endpoints with TCP Ping.
 
         https://github.com/EnginEken/tcppinglib
-    
+
     :copyright: Copyright 2021-2026 Engin EKEN.
     :license: GNU LGPLv3, see the LICENSE for details.
-    
+
     ~~~~~~~
-    
+
     This program is free software: you can redistribute it and/or
     modify it under the terms of the GNU Lesser General Public License
     as published by the Free Software Foundation, either version 3 of
@@ -24,9 +24,9 @@
     <https://www.gnu.org/licenses/>.
 """
 
+import asyncio
 import socket
 import time
-import asyncio
 
 from .models import *
 from .tcp_sockets import *
@@ -40,9 +40,11 @@ def tcpping(
     count: int = 5,
     interval: float = 3,
 ):
+    url = ""
     address = strip_http_https(address)
 
     if is_hostname(address):
+        url = address
         address = hostname_lookup(address, port, socket.AF_INET)[0]
 
     if is_ipv6(address):
@@ -68,7 +70,7 @@ def tcpping(
             except Exception as e:
                 print(e)
 
-    return TCPHost(address, port, count, count - packets_sent, rtts)
+    return TCPHost(address, url, port, count, count - packets_sent, rtts)
 
 
 async def async_tcpping(
@@ -78,9 +80,11 @@ async def async_tcpping(
     count: int = 5,
     interval: float = 3,
 ):
+    url = ""
     address = strip_http_https(address)
 
     if is_hostname(address):
+        url = address
         address = (await async_hostname_lookup(address, port, socket.AF_INET))[0]
 
     if is_ipv6(address):
@@ -106,4 +110,4 @@ async def async_tcpping(
             except Exception as e:
                 print(e)
 
-    return TCPHost(address, port, count, count - packets_sent, rtts)
+    return TCPHost(address, url, port, count, count - packets_sent, rtts)

--- a/tcppinglib/utils.py
+++ b/tcppinglib/utils.py
@@ -1,16 +1,16 @@
 """
     tcppinglib
     ~~~~~~~
-    
+
     Monitor your endpoints with TCP Ping.
 
         https://github.com/EnginEken/tcppinglib
-    
+
     :copyright: Copyright 2021-2026 Engin EKEN.
     :license: GNU LGPLv3, see the LICENSE for details.
-    
+
     ~~~~~~~
-    
+
     This program is free software: you can redistribute it and/or
     modify it under the terms of the GNU Lesser General Public License
     as published by the Free Software Foundation, either version 3 of


### PR DESCRIPTION
TCPHost output currently only prints the resolved ip addresses of urls and this PR adds functionality to print the output in <url>(<resolve_ip>) format if the given destination is fqdn.