### PR TITLE
Review ma ji optional error print

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ It is not only measuring connection overall time to the web server, but also mea
 #### CLI Usage
 ```shell
 $ tcpping --help
-usage: tcpping [-h] [-p PORT] [-t TIMEOUT] [-c COUNT] [-i INTERVAL] address
+usage: tcpping [-h] [-p PORT] [-t TIMEOUT] [-c COUNT] [-i INTERVAL] [--print-errors] address
 ```
 
 #### CLI Arguments
@@ -84,6 +84,14 @@ usage: tcpping [-h] [-p PORT] [-t TIMEOUT] [-c COUNT] [-i INTERVAL] address
     - Type: `float`
     - Default: `1` seconds
 
+- `--print-errors`
+
+    Option to print errors if any occur during ping.
+
+    - Type: `bool`
+    - Default: `False`
+
+
 #### Example
 
 ```shell
@@ -117,7 +125,7 @@ from tcppinglib import tcpping
 #### Function Parameters
 
 ```python
-tcpping(address, port: int = 80, timeout: float = 2, count: int = 3, interval: float = 3)
+tcpping(address, port: int = 80, timeout: float = 2, count: int = 3, interval: float = 3, print_errors: bool = False)
 ```
 
 - `address`
@@ -149,10 +157,17 @@ tcpping(address, port: int = 80, timeout: float = 2, count: int = 3, interval: f
 
 - `interval`
 
-    The interval between sending each packet in seconds
+    The interval between sending each packet in seconds.
 
     - Type: `float`
     - Default: `3` seconds
+
+- `print_errors`
+
+    Option to print errors if any occur during ping.
+
+    - Type: `bool`
+    - Default: `False`
 
 #### Return Value
 
@@ -201,7 +216,7 @@ from tcppinglib import multi_tcpping
 #### Function Parameters
 
 ```python
-multi_tcpping(addresses: list, port: int = 80, timeout: float = 2, count: int = 5, interval: float = 3, concurrent_tasks=50):
+multi_tcpping(addresses: list, port: int = 80, timeout: float = 2, count: int = 5, interval: float = 3, concurrent_tasks=50, print_errors: bool = False):
 ```
 
 - `address`
@@ -244,6 +259,13 @@ multi_tcpping(addresses: list, port: int = 80, timeout: float = 2, count: int = 
 
     - Type: `int`
     - Default: `50`
+
+- `print_errors`
+
+    Option to print errors if any occur during ping.
+
+    - Type: `bool`
+    - Default: `False`
 
 #### Return Value
 
@@ -285,7 +307,7 @@ from tcppinglib import async_tcpping
 #### Function Parameters
 
 ```python
-async_tcpping(address, port: int = 80, timeout: float = 2, count: int = 5, interval: float = 3)
+async_tcpping(address, port: int = 80, timeout: float = 2, count: int = 5, interval: float = 3, print_errors: bool = False)
 ```
 
 - `address`
@@ -322,6 +344,13 @@ async_tcpping(address, port: int = 80, timeout: float = 2, count: int = 5, inter
     - Type: `float`
     - Default: `3` seconds
 
+- `print_errors`
+
+    Option to print errors if any occur during ping.
+
+    - Type: `bool`
+    - Default: `False`
+
 #### Return Value
 
 - A `TcpHost` object will be returned containing with many usefull values about the TCP Ping. <br>
@@ -356,7 +385,7 @@ from tcppinglib import async_multi_tcpping
 #### Function Parameters
 
 ```python
-async_multi_tcpping(address, port: int = 80, timeout: float = 2, count: int = 5, interval: float = 3, concurrent_tasks=50)
+async_multi_tcpping(address, port: int = 80, timeout: float = 2, count: int = 5, interval: float = 3, concurrent_tasks=50, print_errors: bool = False)
 ```
 
 - `address`
@@ -399,6 +428,13 @@ async_multi_tcpping(address, port: int = 80, timeout: float = 2, count: int = 5,
 
     - Type: `int`
     - Default: `50`
+
+- `print_errors`
+
+    Option to print errors if any occur during ping.
+
+    - Type: `bool`
+    - Default: `False`
 
 #### Return Value
 

--- a/tcppinglib/cli.py
+++ b/tcppinglib/cli.py
@@ -77,6 +77,12 @@ def parse_arguments():
         help="Interval in seconds between each ping request (default: 1).",
     )
 
+    parser.add_argument(
+        "--print-errors",
+        action="store_true",
+        help="Print errors if any occur during ping (default: False).",
+    )
+
     return parser.parse_args()
 
 
@@ -105,6 +111,7 @@ def main():
             count=args.count,
             interval=args.interval,
             is_cli=True,
+            print_errors=args.print_errors,
         )
         print(host)
 

--- a/tcppinglib/tcp_multiping.py
+++ b/tcppinglib/tcp_multiping.py
@@ -36,6 +36,7 @@ async def async_multi_tcpping(
     count: int = 5,
     interval: float = 3,
     concurrent_tasks=50,
+    print_errors: bool = False,
 ):
     loop = asyncio.get_running_loop()
     tasks = []
@@ -45,7 +46,9 @@ async def async_multi_tcpping(
             _, tasks_pending = await asyncio.wait(
                 tasks_pending, return_when=asyncio.FIRST_COMPLETED
             )
-        task = loop.create_task(async_tcpping(address, port, timeout, count, interval))
+        task = loop.create_task(
+            async_tcpping(address, port, timeout, count, interval, print_errors)
+        )
         tasks.append(task)
         tasks_pending.add(task)
     await asyncio.wait(tasks_pending)
@@ -59,6 +62,7 @@ def multi_tcpping(
     count: int = 5,
     interval: float = 3,
     concurrent_tasks=50,
+    print_errors: bool = False,
 ):
     return asyncio.run(
         async_multi_tcpping(
@@ -68,5 +72,6 @@ def multi_tcpping(
             count=count,
             interval=interval,
             concurrent_tasks=concurrent_tasks,
+            print_errors=print_errors,
         )
     )

--- a/tcppinglib/tcp_ping.py
+++ b/tcppinglib/tcp_ping.py
@@ -40,6 +40,7 @@ def tcpping(
     count: int = 5,
     interval: float = 3,
     is_cli: bool = False,
+    print_errors: bool = False,
 ):
     url = ""
     address = strip_http_https(address)
@@ -72,7 +73,10 @@ def tcpping(
                     print(TCPCliSeq(address, url, port, sequence, request.time))
 
             except Exception as e:
-                print(e)
+                if print_errors is True:
+                    print(e)
+                else:
+                    pass
 
     return TCPHost(address, url, port, count, count - packets_sent, rtts)
 
@@ -83,6 +87,7 @@ async def async_tcpping(
     timeout: float = 2,
     count: int = 5,
     interval: float = 3,
+    print_errors: bool = False,
 ):
     url = ""
     address = strip_http_https(address)
@@ -112,6 +117,9 @@ async def async_tcpping(
                 rtts.append(request.time)
 
             except Exception as e:
-                print(e)
+                if print_errors is True:
+                    print(e)
+                else:
+                    pass
 
     return TCPHost(address, url, port, count, count - packets_sent, rtts)


### PR DESCRIPTION
- Merges #12 to make error printing optional
- Implements this option in other tcpping functions as well
- Updates README with the new argument
- Adds new cli option as `--print-errors`